### PR TITLE
Update schema.prisma

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
fix below runtime on stag
```
PrismaClientInitializationError: Prisma Client could not locate the Query Engine for runtime "linux-musl-openssl-3.0.x".                                      
This happened because Prisma Client was generated for "linux-musl", but the actual deployment required "linux-musl-openssl-3.0.x".                            
Add "linux-musl-openssl-3.0.x" to `binaryTargets` in the "schema.prisma" file and run `prisma generate` after saving it:                                      
generator client {                                                                                                                                            
  provider      = "prisma-client-js"                                                                                                                          
  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]                                                                                                      
}                                                                                                                                                             
The following locations have been searched:                                                                                                                   
  /app/node_modules/.pnpm/@prisma+client@5.10.2_prisma@5.10.2/node_modules/.prisma/client                                                                     
  /app/node_modules/.pnpm/@prisma+client@5.10.2_prisma@5.10.2/node_modules/@prisma/client                                                                     
  /tmp/prisma-engines                                                                                                                                         
  /app
    at Ea (/app/node_modules/.pnpm/@prisma+client@5.10.2_prisma@5.10.2/node_modules/@prisma/client/runtime/library.js:65:805)
    at async Object.loadLibrary (/app/node_modules/.pnpm/@prisma+client@5.10.2_prisma@5.10.2/node_modules/@prisma/client/runtime/library.js:112:9992)
    at async vt.loadEngine (/app/node_modules/.pnpm/@prisma+client@5.10.2_prisma@5.10.2/node_modules/@prisma/client/runtime/library.js:113:448)
    at async vt.instantiateLibrary (/app/node_modules/.pnpm/@prisma+client@5.10.2_prisma@5.10.2/node_modules/@prisma/client/runtime/library.js:112:12591)
    at async vt.start (/app/node_modules/.pnpm/@prisma+client@5.10.2_prisma@5.10.2/node_modules/@prisma/client/runtime/library.js:113:1981)
    at async Module.o (/app/.next/server/instrumentation.js:1:203)
    at async NextNodeServer.prepareImpl (/app/node_modules/.pnpm/next@14.1.3_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/next-server.js:435:17
) {
  clientVersion: '5.10.2',
  errorCode: undefined
}
```