### PR TITLE
Add error handling and query invalidate

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,14 +86,15 @@ model Profile {
 }
 
 model UserRole {
-  roleName String @id
-  users    User[]
+  roleName    String       @id
+  users       User[]
+  collections Collection[]
 }
 
 model Collection {
   id         String       @id @default(cuid())
   name       String
-  isPublic   Boolean
+  roles      UserRole[]
   form       Form         @relation(fields: [formName], references: [name])
   formName   String
   createdAt  DateTime     @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,15 +92,16 @@ model UserRole {
 }
 
 model Collection {
-  id         String       @id @default(cuid())
-  name       String
-  roles      UserRole[]
-  form       Form         @relation(fields: [formName], references: [name])
-  formName   String
-  createdAt  DateTime     @default(now())
-  updatedAt  DateTime     @updatedAt
-  isOpen     Boolean
-  Submission Submission[]
+  id           String       @id @default(cuid())
+  name         String
+  roles        UserRole[]
+  form         Form         @relation(fields: [formName], references: [name])
+  formName     String
+  instructions String
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+  isOpen       Boolean
+  Submission   Submission[]
 }
 
 model Form {

--- a/src/components/CopyToClipboardButton.tsx
+++ b/src/components/CopyToClipboardButton.tsx
@@ -1,0 +1,32 @@
+import { Fade, IconButton } from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import Check from "@mui/icons-material/Check";
+import { useState } from "react";
+
+interface CopyToClipboardButtonProps {
+  link: string;
+}
+
+const CopyToClipboardButton = ({ link }: CopyToClipboardButtonProps) => {
+  const [clicked, setClicked] = useState(false);
+  const handleClick = () => {
+    void navigator.clipboard.writeText(link);
+    setClicked(true);
+    setTimeout(() => {
+      setClicked(false);
+    }, 2000);
+  };
+  return (
+    <IconButton onClick={handleClick}>
+      {clicked ? (
+        <Fade in={clicked}>
+          <Check />
+        </Fade>
+      ) : (
+        <ContentCopyIcon />
+      )}
+    </IconButton>
+  );
+};
+
+export default CopyToClipboardButton;

--- a/src/components/admin/CollectionForm.tsx
+++ b/src/components/admin/CollectionForm.tsx
@@ -6,21 +6,25 @@ import {
   Button,
   Select,
   MenuItem,
+  FormControl,
+  InputLabel,
+  FormHelperText,
 } from "@mui/material";
 import { Controller, useForm } from "react-hook-form";
 import { api } from "../../utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import DefaultLoadingPage from "../loading/loading";
+import MultipleSelectChip from "../settings/MulitpleSelectChip";
 
 export const createCollectionSchema = z.object({
-  formName: z.string(),
-  // TODO: this should change to visibility, and be an enum
-  // perhaps not visibility, but audience as all forms will require auth
-  isPublic: z.boolean(),
+  formName: z.string().min(1, { message: "Must select a form schema" }),
+  roles: z.array(z.string()).min(1),
   isOpen: z.boolean(),
-  name: z.string(),
+  name: z.string().min(3),
 });
+
+const roles = ["Mentor", "Mentee"];
 
 export type CreateCollectionData = z.infer<typeof createCollectionSchema>;
 
@@ -29,23 +33,30 @@ interface CollectionFormProps {
 }
 
 const CollectionForm = ({ onSubmit }: CollectionFormProps) => {
-  const { data: forms, isLoading } = api.form.getForms.useQuery({});
-  const { handleSubmit, control } = useForm<CreateCollectionData>({
+  const { data: forms, isLoading: formsLoading } = api.form.getForms.useQuery(
+    {},
+  );
+  const { handleSubmit, control, reset } = useForm<CreateCollectionData>({
     resolver: zodResolver(createCollectionSchema),
     defaultValues: {
       formName: "",
-      isPublic: false,
+      roles: [],
       isOpen: false,
       name: "",
     },
   });
-  if (isLoading) {
+  const handleOnSubmit = (data: CreateCollectionData) => {
+    onSubmit(data);
+    reset();
+  };
+  if (formsLoading) {
     return <DefaultLoadingPage />;
   }
   return (
     <Box
       component="form"
-      onSubmit={(...args) => void handleSubmit(onSubmit)(...args)}
+      onSubmit={(...args) => void handleSubmit(handleOnSubmit)(...args)}
+      className="flex flex-col gap-2 "
     >
       <Controller
         control={control}
@@ -61,32 +72,50 @@ const CollectionForm = ({ onSubmit }: CollectionFormProps) => {
       />
       <Controller
         control={control}
-        render={({ field, fieldState: {} }) => (
-          <Select {...field} fullWidth>
-            {forms?.map(({ name }) => (
-              <MenuItem key={name} value={name}>
-                {name}
-              </MenuItem>
-            ))}
-          </Select>
+        render={({ field, fieldState: { error } }) => (
+          <FormControl error={!!error}>
+            <InputLabel>Form Schema</InputLabel>
+            <Select {...field} fullWidth label="Form Schema">
+              {forms?.map(({ name }) => (
+                <MenuItem key={name} value={name}>
+                  {name}
+                </MenuItem>
+              ))}
+            </Select>
+            <FormHelperText>{error?.message}</FormHelperText>
+          </FormControl>
         )}
         name="formName"
       />
       <Controller
         control={control}
-        render={({ field }) => (
-          <FormControlLabel control={<Checkbox />} label="Public" {...field} />
+        render={({ field, fieldState: { error } }) => (
+          <MultipleSelectChip
+            defaultValue={[]}
+            options={roles}
+            editMode
+            error={!!error}
+            helperText={error?.message ?? ""}
+            label="Who should see this form?"
+            updateValue={field.onChange}
+          />
         )}
-        name="isPublic"
+        name="roles"
       />
       <Controller
         control={control}
         render={({ field }) => (
-          <FormControlLabel control={<Checkbox />} label="Open" {...field} />
+          <FormControlLabel
+            control={<Checkbox />}
+            label="Enable collection on creation"
+            {...field}
+          />
         )}
         name="isOpen"
       />
-      <Button type="submit">Create</Button>
+      <Button type="submit" variant="outlined">
+        Create
+      </Button>
     </Box>
   );
 };

--- a/src/components/admin/CollectionForm.tsx
+++ b/src/components/admin/CollectionForm.tsx
@@ -19,9 +19,14 @@ import MultipleSelectChip from "../settings/MulitpleSelectChip";
 
 export const createCollectionSchema = z.object({
   formName: z.string().min(1, { message: "Must select a form schema" }),
-  roles: z.array(z.string()).min(1),
+  roles: z
+    .array(z.string())
+    .min(1, { message: "Must select at least one role" }),
   isOpen: z.boolean(),
-  name: z.string().min(3),
+  name: z.string().min(3, { message: "Name must be at least 3 characters" }),
+  instructions: z
+    .string()
+    .min(1, { message: "Instructions must be at least 1 character" }),
 });
 
 const roles = ["Mentor", "Mentee"];
@@ -43,6 +48,7 @@ const CollectionForm = ({ onSubmit }: CollectionFormProps) => {
       roles: [],
       isOpen: false,
       name: "",
+      instructions: "",
     },
   });
   const handleOnSubmit = (data: CreateCollectionData) => {
@@ -69,6 +75,20 @@ const CollectionForm = ({ onSubmit }: CollectionFormProps) => {
           />
         )}
         name="name"
+      />
+      <Controller
+        control={control}
+        render={({ field, fieldState: { error } }) => (
+          <TextField
+            multiline
+            minRows={4}
+            label="Form Instructions"
+            {...field}
+            error={!!error}
+            helperText={error?.message}
+          />
+        )}
+        name="instructions"
       />
       <Controller
         control={control}

--- a/src/pages/admin/collections.tsx
+++ b/src/pages/admin/collections.tsx
@@ -14,28 +14,37 @@ import CollectionForm, {
 } from "../../components/admin/CollectionForm";
 import DefaultLoadingPage from "../../components/loading/loading";
 import ErrorPage from "../../components/error/error";
+import { sentenceCase } from "../../utils/roles";
+import CopyToClipboardButton from "../../components/CopyToClipboardButton";
 
 const Collections = () => {
+  const utils = api.useUtils();
   const { data, error, isLoading } = api.collection.getCollections.useQuery();
-  // TODO: error handling decision
-  const { mutateAsync } = api.collection.createCollection.useMutation();
+  const { mutateAsync } = api.collection.createCollection.useMutation({
+    onSuccess: async () => {
+      await utils.collection.getCollections.invalidate();
+    },
+  });
   const onSubmit: SubmitHandler<CreateCollectionData> = async (data) => {
-    debugger;
-    await mutateAsync(data);
+    await mutateAsync({
+      ...data,
+      roles: data.roles.map((role) => role.toUpperCase()),
+    });
   };
   if (isLoading) return <DefaultLoadingPage />;
   if (error) return <ErrorPage errorMessage={error.message} />;
   return (
-    <Container>
+    <Container className="mt-4">
       <CollectionForm onSubmit={onSubmit} />
       <TableContainer>
         <Table>
           <TableHead>
             <TableRow>
               <TableCell>Collection Name</TableCell>
-              <TableCell>Form Name</TableCell>
-              <TableCell>Public</TableCell>
+              <TableCell>Form Schema</TableCell>
+              <TableCell>Roles</TableCell>
               <TableCell>Open</TableCell>
+              <TableCell>Link</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -43,8 +52,17 @@ const Collections = () => {
               <TableRow key={collection.id}>
                 <TableCell>{collection.name}</TableCell>
                 <TableCell>{collection.formName}</TableCell>
-                <TableCell>{collection.isPublic ? "Yes" : "No"}</TableCell>
+                <TableCell>
+                  {collection.roles
+                    .map(({ roleName }) => sentenceCase(roleName))
+                    .join(", ")}
+                </TableCell>
                 <TableCell>{collection.isOpen ? "Yes" : "No"}</TableCell>
+                <TableCell>
+                  <CopyToClipboardButton
+                    link={`${window.location.origin}/form/${collection.id}`}
+                  />
+                </TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/src/pages/form/[id].tsx
+++ b/src/pages/form/[id].tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 import { type JSONObject } from "superjson/dist/types";
 import DefaultLoadingPage from "../../components/loading/loading";
 import ErrorPage from "../../components/error/error";
+import { Container, Typography } from "@mui/material";
 
 /**
  * Form page that gets the collection by id and renders the form based
@@ -29,15 +30,20 @@ const Form = () => {
     submit({ collectionId: router.query.id as string, data });
   };
   return (
-    <>
-      {/* Info panel about form customizable when it is created */}
+    <Container className="flex flex-col p-4">
+      <Typography variant="h4" className="mb-4">
+        {data.name}
+      </Typography>
+      <Typography variant="body1" className="mb-4">
+        {data.instructions}
+      </Typography>
       <JsonForm
         schema={formSchema}
         uischema={uiSchema}
         initialData={{}}
         onSubmit={onSubmit}
       />
-    </>
+    </Container>
   );
 };
 

--- a/src/server/api/routers/collection.ts
+++ b/src/server/api/routers/collection.ts
@@ -7,37 +7,40 @@ import { createCollectionSchema } from "../../../components/admin/CollectionForm
 export const collectionRouter = createTRPCRouter({
   createCollection: publicProcedure
     .input(createCollectionSchema)
-    .mutation(async ({ input: { name, formName, roles, isOpen } }) => {
-      try {
-        const form = await db.form.findFirst({
-          where: {
-            name: formName,
-          },
-        });
-        if (!form) {
+    .mutation(
+      async ({ input: { name, instructions, formName, roles, isOpen } }) => {
+        try {
+          const form = await db.form.findFirst({
+            where: {
+              name: formName,
+            },
+          });
+          if (!form) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Form not found",
+            });
+          }
+          const collection = await db.collection.create({
+            data: {
+              name,
+              formName,
+              instructions,
+              isOpen,
+              roles: {
+                connect: roles.map((roleName) => ({ roleName })),
+              },
+            },
+          });
+          return collection;
+        } catch (error) {
           throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Form not found",
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Error creating collection",
           });
         }
-        const collection = await db.collection.create({
-          data: {
-            name,
-            formName,
-            isOpen,
-            roles: {
-              connect: roles.map((roleName) => ({ roleName })),
-            },
-          },
-        });
-        return collection;
-      } catch (error) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Error creating collection",
-        });
-      }
-    }),
+      },
+    ),
   getCollectionById: publicProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ input: { id } }) => {

--- a/src/server/api/routers/collection.ts
+++ b/src/server/api/routers/collection.ts
@@ -7,7 +7,7 @@ import { createCollectionSchema } from "../../../components/admin/CollectionForm
 export const collectionRouter = createTRPCRouter({
   createCollection: publicProcedure
     .input(createCollectionSchema)
-    .mutation(async ({ input: { name, formName, isPublic, isOpen } }) => {
+    .mutation(async ({ input: { name, formName, roles, isOpen } }) => {
       try {
         const form = await db.form.findFirst({
           where: {
@@ -23,9 +23,11 @@ export const collectionRouter = createTRPCRouter({
         const collection = await db.collection.create({
           data: {
             name,
-            isPublic,
-            isOpen,
             formName,
+            isOpen,
+            roles: {
+              connect: roles.map((roleName) => ({ roleName })),
+            },
           },
         });
         return collection;
@@ -57,7 +59,7 @@ export const collectionRouter = createTRPCRouter({
       return collection;
     }),
   getCollections: publicProcedure.query(async () => {
-    return db.collection.findMany();
+    return db.collection.findMany({ include: { roles: true } });
   }),
   getSubmissions: publicProcedure
     .input(z.object({ collectionId: z.string() }))

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -1,0 +1,2 @@
+export const sentenceCase = (role: string) =>
+  `${role[0]?.toUpperCase()}${role.slice(1).toLowerCase()}`;


### PR DESCRIPTION
This commit enchances the collections form for admin use, adding error messages to fields, adding roles to collection creation, invalidating collections table on mutation success, and some styling changes.

![image](https://github.com/stevensblueprint/aad-admin/assets/92767187/86265193-6745-44e2-9412-a14927352a86)
![image](https://github.com/stevensblueprint/aad-admin/assets/92767187/8b79b158-dc07-4bbe-906a-e2000913b976)
![image](https://github.com/stevensblueprint/aad-admin/assets/92767187/79e7cf55-5876-4336-a255-4f7b8f4a0b37)

Future styling changes for form https://github.com/stevensblueprint/aad-admin/issues/159
